### PR TITLE
Make parser less strict

### DIFF
--- a/internal/parser/trsrules/parseTRS.go
+++ b/internal/parser/trsrules/parseTRS.go
@@ -84,18 +84,18 @@ type Parser struct {
 
 func (p *Parser) makeLexemError(l models.Lexem, Ltype models.LexemType, message, llmMessage string) error {
 	//fmt.Printf("%s\n",message)
-	if len(p.errors) >= 1{
+	if len(p.errors) >= 1 {
 		return models.NewParseError(
-		fmt.Sprintf("at %d:%d unexpected symbol \"%s\" of type %s", 
-			p.errors[0].Line, p.errors[0].Index, p.errors[0].Str, models.GetLexemInterpretation(p.errors[0].LexemType)), 
-		fmt.Sprintf("на позиции %d:%d неожиданный символ \"%s\" типа %s", 
-			p.errors[0].Line, p.errors[0].Index, p.errors[0].Str, models.GetLexemInterpretation(p.errors[0].LexemType)),
+			fmt.Sprintf("at %d:%d unexpected symbol \"%s\" of type %s",
+				p.errors[0].Line, p.errors[0].Index, p.errors[0].Str, models.GetLexemInterpretation(p.errors[0].LexemType)),
+			fmt.Sprintf("на позиции %d:%d неожиданный символ \"%s\" типа %s",
+				p.errors[0].Line, p.errors[0].Index, p.errors[0].Str, models.GetLexemInterpretation(p.errors[0].LexemType)),
 		)
 	}
-	if Ltype < 0 || Ltype == models.LexLETTER || Ltype == models.LexNUM || Ltype == models.LexVAR{
+	if Ltype < 0 || Ltype == models.LexLETTER || Ltype == models.LexNUM || Ltype == models.LexVAR {
 		return models.NewParseError(message, llmMessage)
 	}
-	p.errors = append(p.errors, l)// = append(p.errors, err)
+	p.errors = append(p.errors, l) // = append(p.errors, err)
 	p.index--
 	return nil
 }
@@ -121,7 +121,7 @@ func (p *Parser) isVariable(l models.Lexem) bool {
 
 func (p *Parser) lexCheck(l models.Lexem, Ltype models.LexemType) error {
 	//fmt.Printf("%d:%d %s t=%d exp=%d\n", l.Line, l.Index, l.Str, l.LexemType, Ltype)
-	
+
 	if l.LexemType != Ltype {
 		switch l.LexemType {
 		/*case models.LexLB:
@@ -132,9 +132,9 @@ func (p *Parser) lexCheck(l models.Lexem, Ltype models.LexemType) error {
 			if l.LexemType == models.LexNUM || l.LexemType == models.LexLETTER {
 				return_str = l.Str
 			}
-			return p.makeLexemError(l, Ltype, 
+			return p.makeLexemError(l, Ltype,
 				fmt.Sprintf("at %d:%d expected %s, found %s",
-						l.Line, l.Index, models.GetLexemInterpretation(Ltype), return_str),
+					l.Line, l.Index, models.GetLexemInterpretation(Ltype), return_str),
 				fmt.Sprintf("в строке %d TRS  на позиции %d ожидалось \"%s\", найдено \"%s\"",
 					l.Line, l.Index, models.GetLexemInterpretation(Ltype), return_str),
 			)

--- a/internal/parser/trsrules/parseTRS_test.go
+++ b/internal/parser/trsrules/parseTRS_test.go
@@ -79,9 +79,8 @@ func TestParserWithVarAsConstructor(t *testing.T) {
 
 func TestMind(t *testing.T) {
 	input := `variables=x
-f(x, f(x,x)) = f(xa, f(x,x))
+f(x) = 
 -------`
-
 	l := lexer.Lexer{Text: input}
 	err := l.Process()
 	if err != nil {

--- a/internal/parser/trsrules/parseTRS_test.go
+++ b/internal/parser/trsrules/parseTRS_test.go
@@ -8,8 +8,6 @@ import (
 
 const (
 	peano            string = "variables = x,y,z\n\n\n\n f(x,S(y)) = S(f(x,y)) \n\r f(x, T) = T\n-------------S(x) = x+1\nf(x,y)=    x+2*y"
-	wrongVar         string = "variables = x,y,z\n f(x, y) = f(x, z)\n-------f(x,y)     = xy"
-	varError         string = "variables = x, y,\n f(x,y) = f(x,y)\n--------f(x,y) = x+y"
 	wrongConstructor        = "variables = x,y,z\n f(x,y) = f(x)\n----------f(x,y) = x"
 )
 
@@ -28,6 +26,7 @@ func TestParserWithPeano(t *testing.T) {
 	}
 }
 func TestParserWithWrongVar(t *testing.T) {
+	wrongVar := "variables = x,y,z\n f(x, y) = f(x, z)\n-------f(x,y)     = xy"
 	l := lexer.Lexer{Text: wrongVar}
 	err := l.Process()
 	if err != nil {
@@ -40,6 +39,7 @@ func TestParserWithWrongVar(t *testing.T) {
 	}
 }
 func TestParserWithVarError(t *testing.T) {
+	varError := "variables = x, y,\n f(x,y) = f(x,y)\n--------f(x,y) = x+y"
 	l := lexer.Lexer{Text: varError}
 	err := l.Process()
 	if err != nil {
@@ -47,7 +47,7 @@ func TestParserWithVarError(t *testing.T) {
 	}
 
 	_, _, err1 := ParseRules(l.Lexem)
-	if err1.Error() != "at 1:18 expected буква, found конец строки" {
+	if err1 != nil && err1.Error() != "at 1:18 expected буква, found конец строки" {
 		t.Error(err1)
 	}
 }
@@ -89,9 +89,9 @@ f(x, f(x,x)) = f(xa, f(x,x))
 	}
 
 	_, _, err1 := ParseRules(l.Lexem)
-	if err1 != nil {
-		t.Error(err1)
-	}
+	//if err1 != nil {
+	//	t.Error(err1)
+	//}
 	if err1 == nil {
 		t.Error("должен бросать ошибку о неправильной лексеме в второй строчке")
 	}

--- a/internal/parser/trsrules/parseTRS_test.go
+++ b/internal/parser/trsrules/parseTRS_test.go
@@ -79,7 +79,7 @@ func TestParserWithVarAsConstructor(t *testing.T) {
 
 func TestMind(t *testing.T) {
 	input := `variables=x
-x(x, g(y)) = g(f(x))
+f(x, f(x,x)) = f(xa, f(x,x))
 -------`
 
 	l := lexer.Lexer{Text: input}
@@ -89,6 +89,9 @@ x(x, g(y)) = g(f(x))
 	}
 
 	_, _, err1 := ParseRules(l.Lexem)
+	if err1 != nil {
+		t.Error(err1)
+	}
 	if err1 == nil {
 		t.Error("должен бросать ошибку о неправильной лексеме в второй строчке")
 	}

--- a/internal/parser/trsrules/parseTRS_test.go
+++ b/internal/parser/trsrules/parseTRS_test.go
@@ -35,8 +35,8 @@ func TestParserWithWrongVar(t *testing.T) {
 	}
 
 	_, _, err1 := ParseRules(l.Lexem)
-	if err1 == nil {
-		t.Errorf("Должен кидать ошибку о несовпадающих переменных в правиле переписывания")
+	if err1.Error() != "in rule 1 var mismatch: z cant be used" {
+		t.Error(err1)
 	}
 }
 func TestParserWithVarError(t *testing.T) {
@@ -47,8 +47,8 @@ func TestParserWithVarError(t *testing.T) {
 	}
 
 	_, _, err1 := ParseRules(l.Lexem)
-	if err1 == nil {
-		t.Errorf("Должен кидать ошибку в объявлении переменных")
+	if err1.Error() != "at 1:18 expected буква, found конец строки" {
+		t.Error(err1)
 	}
 }
 func TestParserWithConstructorError(t *testing.T) {
@@ -59,8 +59,8 @@ func TestParserWithConstructorError(t *testing.T) {
 	}
 
 	_, _, err1 := ParseRules(l.Lexem)
-	if err1 == nil {
-		t.Errorf("Должен кидать ошибку о неправильном количестве переменных в конструкторе")
+	if err1.Error() != "in line 2 constructor mismatch f: expect 2 args, found 1 args" {
+		t.Error(err1)
 	}
 }
 
@@ -72,8 +72,8 @@ func TestParserWithVarAsConstructor(t *testing.T) {
 	}
 
 	_, _, err1 := ParseRules(l.Lexem)
-	if err1 == nil {
-		t.Error("Должен кидать ошибку о неправильной скобочной структуре")
+	if err1.Error() != "in line 2 at 1 var x used as constructor" {
+		t.Error(err1)
 	}
 }
 

--- a/internal/parser/trsrules/parseTRS_test.go
+++ b/internal/parser/trsrules/parseTRS_test.go
@@ -79,8 +79,11 @@ func TestParserWithVarAsConstructor(t *testing.T) {
 
 func TestMind(t *testing.T) {
 	input := `variables=x
-f(x) = 
--------`
+f(x,g(x,y,y) = f(x,y)
+----------
+f(x,y,z) = x+y
+y = 0
+g(x,y) = x*y`
 	l := lexer.Lexer{Text: input}
 	err := l.Process()
 	if err != nil {
@@ -88,10 +91,10 @@ f(x) =
 	}
 
 	_, _, err1 := ParseRules(l.Lexem)
-	//if err1 != nil {
-	//	t.Error(err1)
-	//}
-	if err1 == nil {
-		t.Error("должен бросать ошибку о неправильной лексеме в второй строчке")
+	if err1 != nil {
+		t.Error(err1)
 	}
+	//if err1 == nil {
+	//	t.Error("должен бросать ошибку о неправильной лексеме в второй строчке")
+	//}
 }

--- a/pkg/trsparser/parser_test.go
+++ b/pkg/trsparser/parser_test.go
@@ -678,12 +678,12 @@ func newInt(v int) *int {
 
 func TestSpecificRules(t *testing.T) {
 	/*исходный тест исправленный по ошибкам
-	`variables=x
-f(x,g(x,y,y) = f(x,y)
-----------
-f(x,y,z) = x+y
-y = 0
-g(x,y) = x*y`
+		`variables=x
+	f(x,g(x,y,y) = f(x,y)
+	----------
+	f(x,y,z) = x+y
+	y = 0
+	g(x,y) = x*y`
 	*/
 
 	_, err := Parser{}.Parse(

--- a/pkg/trsparser/parser_test.go
+++ b/pkg/trsparser/parser_test.go
@@ -176,7 +176,7 @@ f(x = x
 f(x) = 5
 `,
 	)
-	if err != nil{
+	if err != nil {
 		assert.ErrorAs(t, err, &parseError)
 		assert.Equal(
 			t,
@@ -184,7 +184,7 @@ f(x) = 5
 			parseError.LlmMessage,
 		)
 	}
-	
+
 }
 
 func TestMissingEqualSignAtVariablesBlock(t *testing.T) {
@@ -197,13 +197,13 @@ f(x) = x
 f(x) = 5
 `,
 	)
-	if err != nil{
-	assert.ErrorAs(t, err, &parseError)
-	assert.Equal(
-		t,
-		`в строке 1 TRS  на позиции 11 ожидалось "=", найдено "x"`,
-		parseError.LlmMessage,
-	)
+	if err != nil {
+		assert.ErrorAs(t, err, &parseError)
+		assert.Equal(
+			t,
+			`в строке 1 TRS  на позиции 11 ожидалось "=", найдено "x"`,
+			parseError.LlmMessage,
+		)
 	}
 }
 

--- a/pkg/trsparser/parser_test.go
+++ b/pkg/trsparser/parser_test.go
@@ -177,7 +177,7 @@ f(x) = 5
 `,
 	)
 	assert.NoError(t, err)
-	
+
 }
 
 func TestMissingEqualSignAtVariablesBlock(t *testing.T) {

--- a/pkg/trsparser/parser_test.go
+++ b/pkg/trsparser/parser_test.go
@@ -675,3 +675,25 @@ T = 0
 func newInt(v int) *int {
 	return &v
 }
+
+func TestSpecificRules(t *testing.T) {
+	/*исходный тест исправленный по ошибкам
+	`variables=x
+f(x,g(x,y,y) = f(x,y)
+----------
+f(x,y,z) = x+y
+y = 0
+g(x,y) = x*y`
+	*/
+
+	_, err := Parser{}.Parse(
+		`variables=x
+f(x,g(x,y),y) = f(x,y,y)
+----------
+f(x,y,z) = x+y
+y = 0
+g(x,y) = xy
+`,
+	)
+	assert.NoError(t, err)
+}

--- a/pkg/trsparser/parser_test.go
+++ b/pkg/trsparser/parser_test.go
@@ -26,12 +26,10 @@ func TestErrorOnJustEOL(t *testing.T) {
 	_, err := Parser{}.Parse(`
 
 `)
-
 	assert.ErrorAs(t, err, &parseError)
 	assert.Equal(
 		t,
-		`в начале TRS ожидалось перечисление переменных формата "variables = x,y,z": `+
-			`в строке 1 TRS  на позиции 1 ожидалось "variables", найдено "конец строки"`,
+		`в начале TRS ожидалось перечисление переменных формата "variables = x,y,z"`,
 		parseError.LlmMessage,
 	)
 }
@@ -178,13 +176,15 @@ f(x = x
 f(x) = 5
 `,
 	)
-
-	assert.ErrorAs(t, err, &parseError)
-	assert.Equal(
-		t,
-		`в строке 2 TRS  на позиции 5 ожидалось ")", найдено "="`,
-		parseError.LlmMessage,
-	)
+	if err != nil{
+		assert.ErrorAs(t, err, &parseError)
+		assert.Equal(
+			t,
+			`в строке 2 TRS  на позиции 5 ожидалось ")", найдено "="`,
+			parseError.LlmMessage,
+		)
+	}
+	
 }
 
 func TestMissingEqualSignAtVariablesBlock(t *testing.T) {
@@ -197,13 +197,14 @@ f(x) = x
 f(x) = 5
 `,
 	)
-
+	if err != nil{
 	assert.ErrorAs(t, err, &parseError)
 	assert.Equal(
 		t,
 		`в строке 1 TRS  на позиции 11 ожидалось "=", найдено "x"`,
 		parseError.LlmMessage,
 	)
+	}
 }
 
 func TestCoefficientAfterVariable(t *testing.T) {

--- a/pkg/trsparser/parser_test.go
+++ b/pkg/trsparser/parser_test.go
@@ -167,7 +167,7 @@ f(x = 5
 }
 
 func TestExcessClosingBracketInRules(t *testing.T) {
-	var parseError *ParseError
+	//var parseError *ParseError
 
 	_, err := Parser{}.Parse(
 		`variables = x
@@ -176,19 +176,12 @@ f(x = x
 f(x) = 5
 `,
 	)
-	if err != nil {
-		assert.ErrorAs(t, err, &parseError)
-		assert.Equal(
-			t,
-			`в строке 2 TRS  на позиции 5 ожидалось ")", найдено "="`,
-			parseError.LlmMessage,
-		)
-	}
-
+	assert.NoError(t, err)
+	
 }
 
 func TestMissingEqualSignAtVariablesBlock(t *testing.T) {
-	var parseError *ParseError
+	//var parseError *ParseError
 
 	_, err := Parser{}.Parse(
 		`variables x
@@ -197,14 +190,7 @@ f(x) = x
 f(x) = 5
 `,
 	)
-	if err != nil {
-		assert.ErrorAs(t, err, &parseError)
-		assert.Equal(
-			t,
-			`в строке 1 TRS  на позиции 11 ожидалось "=", найдено "x"`,
-			parseError.LlmMessage,
-		)
-	}
+	assert.NoError(t, err)
 }
 
 func TestCoefficientAfterVariable(t *testing.T) {


### PR DESCRIPTION
Предлагаю изменения, которые делают парсер менее строгим к ошибкам. По следующему правилу:
- Если в парсере ошибка завязанная на специальные символы(скобочки, запятые и прочие) - то есть ошибка в структуре выражения. То пытаемся обработать не смотря на эту ошибку.
- При встрече второй такой ошибки отправляем сообщение о первой ошибке, которое просто говорит о том, что там что-то не так
- Ошибки завязанные на корректность имен или использования конструкторов не были затронуты


Прошу проверить реализацию и предложить тесты, для которых это не работает. 

Также в комитах были улучшены следующие ошибки:
- реагирование на неправильное число аргументов в время разбора а не после, что позволяет отловить некоторые тесты
- использование переменной как имени конструктора